### PR TITLE
Allow fetching the result code from Next

### DIFF
--- a/pcap.go
+++ b/pcap.go
@@ -104,11 +104,25 @@ func Openoffline(file string) (handle *Pcap, err string) {
 }
 
 func (p *Pcap) Next() (pkt *Packet) {
+	rv, _ := p.NextEx()
+
+	return rv
+}
+
+func (p *Pcap) NextEx() (pkt *Packet, result int32) {
+	var pkthdr_ptr *_Ctype_struct_pcap_pkthdr
 	var pkthdr _Ctype_struct_pcap_pkthdr
+
+	var buf_ptr *_Ctypedef_u_char
 	var buf unsafe.Pointer
-	buf = unsafe.Pointer(C.pcap_next(p.cptr, &pkthdr))
+	result = int32(C.pcap_next_ex(p.cptr, &pkthdr_ptr, &buf_ptr))
+
+	buf = unsafe.Pointer(buf_ptr)
+	pkthdr = *pkthdr_ptr
+
 	if nil == buf {
-		return nil
+		pkt = nil
+		return
 	}
 	pkt = new(Packet)
 	pkt.Time.Sec = int32(pkthdr.ts.tv_sec)


### PR DESCRIPTION
In some cases, you want to know what the result code was of asking for a packet.  This pull request adds a new function "NextEx" which lets you do that.  The "Next" function is rewritten to use the former function and explicitly throw away the result code.
