### PR TITLE
Make gopcap goinstallable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ TARG=pcap
 GOFILES=decode.go\
 	io.go
 CGOFILES=pcap.go
-CGO_LDFLAGS=-lpcap
 CLEANFILES=pcaptest tcpdump
 
 include $(GOROOT)/src/Make.pkg

--- a/pcap.go
+++ b/pcap.go
@@ -1,6 +1,7 @@
 package pcap
 
 /*
+#cgo LDFLAGS: -lpcap
 struct pcap { int dummy; };
 #include <stdlib.h>
 #include <pcap.h>


### PR DESCRIPTION
The Makefile is ignored by goinstall. This small change allows users of
the wrapper to use goinstall to easily install the wrapper. See
http://golang.org/cmd/goinstall/ for more information.
