### PR TITLE
Change decodeIp to only consider use up to byte Length bytes.

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -230,7 +230,11 @@ func (p *Packet) decodeIp() {
 	ip.Checksum = decodeuint16(pkt[10:12])
 	ip.SrcIp = pkt[12:16]
 	ip.DestIp = pkt[16:20]
-	p.Payload = pkt[ip.Ihl*4:]
+	pEnd := int(ip.Length)
+	if pEnd > len(pkt) {
+		pEnd = len(pkt)
+	}
+	p.Payload = pkt[ip.Ihl*4 : pEnd]
 	p.Headers = append(p.Headers, ip)
 
 	switch ip.Protocol {


### PR DESCRIPTION
This solves the issue where Ethernet packets must be a minimum of 60 bytes, but
can take up only 54 bytes on the wire if there's no payload added.  Without
this change, packets of that type may appear to be TCP packets with 6 null bytes
in their payload.

See
http://forums.devshed.com/networking-help-109/tcp-protocol-mysterious-6-null-byte-payload-303357.html
for more discussion on this.
