### PR TITLE
Fixed typo in decode.go

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -244,7 +244,7 @@ type Vlanhdr struct {
 }
 
 func (v *Vlanhdr) String() {
-	fmt.Sprintf("VLAN Prioity:%d Drop:%v Tag:%d", v.Prioity, v.DropEligible, v.VlanIdentifier)
+	fmt.Sprintf("VLAN Priority:%d Drop:%v Tag:%d", v.Priority, v.DropEligible, v.VlanIdentifier)
 }
 
 func (p *Packet) decodeVlan() {


### PR DESCRIPTION
s/Prioity/Priority/

Thanks for creating this! Go needs something as awesome as Python's [scapy](http://www.secdev.org/projects/scapy/demo.html) btw, though it'll be hard to compete with.
