### PR TITLE
Fixed precision of timestmaps.

### DIFF
--- a/pcap.go
+++ b/pcap.go
@@ -107,7 +107,7 @@ func (p *Pcap) NextEx() (pkt *Packet, result int32) {
 		return
 	}
 	pkt = new(Packet)
-	pkt.Time = time.Unix(int64(pkthdr.ts.tv_sec), int64(pkthdr.ts.tv_usec))
+	pkt.Time = time.Unix(int64(pkthdr.ts.tv_sec), int64(pkthdr.ts.tv_usec)*1000)
 	pkt.Caplen = uint32(pkthdr.caplen)
 	pkt.Len = uint32(pkthdr.len)
 	pkt.Data = make([]byte, pkthdr.caplen)


### PR DESCRIPTION
The C pcap library uses {sec,usec} for timestamps, where usec are
microsconds. Go's time.Time have nanosecond precisions, so we need
to convert between the two.
