### PR TITLE
fixing tcpdump's Usage errorout feedback on invalid cmdline args

### DIFF
--- a/tools/tcpdump/tcpdump.go
+++ b/tools/tcpdump/tcpdump.go
@@ -34,6 +34,7 @@ func main() {
 
 	flag.Usage = func() {
 		fmt.Fprintf(errout, "usage: %s [ -i interface ] [ -s snaplen ] [ -X ] [ expression ]\n", os.Args[0])
+		errout.Flush()
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
If you improperly call the tcpdump tool, no error feedback is written to stdout.  There is a missing flush call on the errout writer. 

You will now get the friendly feedback:
usage: ./tcpdump [ -i interface ] [ -s snaplen ] [ -X ] [ expression ]
